### PR TITLE
A small number of tests

### DIFF
--- a/lua/tests/gmod/globals/Vector.lua
+++ b/lua/tests/gmod/globals/Vector.lua
@@ -19,22 +19,22 @@ return {
         {
             name = "Accepts string-number parameters",
             func = function()
-                local vector = Vector( "1", "2", "3" )
+                local vector = Vector( "1", "100.000", "0.1" )
 
                 expect( vector.x ).to.equal( 1 )
-                expect( vector.y ).to.equal( 2 )
-                expect( vector.z ).to.equal( 3 )
+                expect( vector.y ).to.equal( 100 )
+                expect( vector.z ).to.beBetween( 0.09, 0.11 )
             end
         },
 
         {
             name = "Accepts string parameters",
             func = function()
-                local vector = Vector( "1 2 3" )
+                local vector = Vector( "1 100.000 0.1" )
 
                 expect( vector.x ).to.equal( 1 )
-                expect( vector.y ).to.equal( 2 )
-                expect( vector.z ).to.equal( 3 )
+                expect( vector.y ).to.equal( 100 )
+                expect( vector.z ).to.beBetween( 0.09, 0.11 )
             end
         },
 

--- a/lua/tests/gmod/globals/Vector.lua
+++ b/lua/tests/gmod/globals/Vector.lua
@@ -41,6 +41,7 @@ return {
         {
             name = "Rolls back the invalid value to 0",
             func = function()
+                --X
                 local vector = Vector( 128, nil, -128 )
                 expect( vector.x ).to.equal( 128 )
                 expect( vector.y ).to.equal( 0 )
@@ -55,6 +56,38 @@ return {
                 expect( vector.x ).to.equal( 128 )
                 expect( vector.y ).to.equal( 0 )
                 expect( vector.z ).to.equal( -128 )
+
+                --Y
+                local vector = Vector( nil, 0, -128 )
+                expect( vector.x ).to.equal( 0 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+
+                vector = Vector( {}, 0, -128 )
+                expect( vector.x ).to.equal( 0 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+
+                vector = Vector( "bad_string", 0, -128 )
+                expect( vector.x ).to.equal( 0 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+
+                --Z
+                local vector = Vector( 128, 0, nil )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 0 )
+
+                vector = Vector( 128, 0, {} )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 0 )
+
+                vector = Vector( 128, 0, "bad_string" )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 0 )
             end
         },
 
@@ -77,6 +110,37 @@ return {
                 expect( vector.x ).to.equal( -128 )
                 expect( vector.y ).to.equal( 0 )
                 expect( vector.z ).to.equal( 128 )
+            end
+        },
+
+        {
+            name = "Accepts crazy and very small values",
+            func = function()
+                local vector = Vector( math.huge, math.huge, math.huge )
+
+                expect( vector.x ).to.equal( math.huge )
+                expect( vector.y ).to.equal( math.huge )
+                expect( vector.z ).to.equal( math.huge )
+
+                vector = Vector( -math.huge, -math.huge, -math.huge )
+                expect( vector.x ).to.equal( -math.huge )
+                expect( vector.y ).to.equal( -math.huge )
+                expect( vector.z ).to.equal( -math.huge )
+
+                vector = Vector( 0 / 0, 0 / 0, 0 / 0 )
+                expect( vector.x ).toNot.equal( vector.x )
+                expect( vector.y ).toNot.equal( vector.y )
+                expect( vector.z ).toNot.equal( vector.z )
+
+                vector = Vector( 0.001, 0.0001, 0.00001 )
+                expect( vector.x ).to.beBetween( 0.0009, 0.0011 )
+                expect( vector.y ).to.beBetween( 0.00009, 0.00011 )
+                expect( vector.z ).to.beBetween( 0.000009, 0.000011 )
+
+                vector = Vector( -0.001, -0.0001, -0.00001 )
+                expect( vector.x ).to.beBetween( -0.0011, -0.0009 )
+                expect( vector.y ).to.beBetween( -0.00011, -0.00009 )
+                expect( vector.z ).to.beBetween( -0.000011, -0.000009 )
             end
         },
 

--- a/lua/tests/gmod/globals/Vector.lua
+++ b/lua/tests/gmod/globals/Vector.lua
@@ -1,0 +1,94 @@
+return {
+    groupName = "Global:Vector",
+    cases = {
+        {
+            name = "Exists in the global table",
+            func = function()
+                expect( Vector ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns an Vector object",
+            func = function()
+                local vector = Vector( 1, 2, 3 )
+                expect( vector ).to.beA( "Vector" )
+            end
+        },
+
+        {
+            name = "Accepts string-number parameters",
+            func = function()
+                local vector = Vector( "1", "2", "3" )
+
+                expect( vector.x ).to.equal( 1 )
+                expect( vector.y ).to.equal( 2 )
+                expect( vector.z ).to.equal( 3 )
+            end
+        },
+
+        {
+            name = "Accepts string parameters",
+            func = function()
+                local vector = Vector( "1 2 3" )
+
+                expect( vector.x ).to.equal( 1 )
+                expect( vector.y ).to.equal( 2 )
+                expect( vector.z ).to.equal( 3 )
+            end
+        },
+
+        {
+            name = "Rolls back the invalid value to 0",
+            func = function()
+                local vector = Vector( 128, nil, -128 )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+
+                vector = Vector( 128, {}, -128 )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+
+                vector = Vector( 128, "bad_string", -128 )
+                expect( vector.x ).to.equal( 128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( -128 )
+            end
+        },
+
+        {
+            name = "Returns Vector( 0, 0, 0 ) if the string is invalid",
+            func = function()
+                local vector = Vector( "bad_string" )
+
+                expect( vector.x ).to.equal( 0 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 0 )
+            end
+        },
+
+        {
+            name = "Accepts negative numbers",
+            func = function()
+                local vector = Vector( -128, 0, 128 )
+
+                expect( vector.x ).to.equal( -128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 128 )
+            end
+        },
+
+        {
+            name = "Copies vector",
+            func = function()
+                local vector = Vector( Vector( -128, 0, 128 ) )
+
+                expect( vector.x ).to.equal( -128 )
+                expect( vector.y ).to.equal( 0 )
+                expect( vector.z ).to.equal( 128 )
+            end
+        },
+    }
+}

--- a/lua/tests/gmod/globals/VectorRand.lua
+++ b/lua/tests/gmod/globals/VectorRand.lua
@@ -1,0 +1,33 @@
+return {
+    groupName = "Global:VectorRand",
+    cases = {
+        {
+            name = "Exists in the global table",
+            func = function()
+                expect( VectorRand ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns an Vector",
+            func = function()
+                expect( VectorRand() ).to.beAn( "Vector" )
+            end
+        },
+
+        {
+            name = "Returns an Vector within the specified range",
+            func = function()
+                local min = -128
+                local max = 128
+
+                local out = VectorRand( min, max )
+                local x, y, z = out.x, out.y, out.z
+
+                expect( x ).to.beBetween( min, max )
+                expect( y ).to.beBetween( min, max )
+                expect( z ).to.beBetween( min, max )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/globals/isangle.lua
+++ b/lua/tests/gmod/globals/isangle.lua
@@ -12,10 +12,10 @@ return {
             name = "Returns the right bool",
             func = function()
                 local angle = Angle( 1, 2, 3 )
-                expect( isangle( angle ) ).to.beTrue()
+                local vector = Vector( 1, 2, 3 )
 
-                local fake_angle = setmetatable( { p = 1, y = 2, r = 3 }, getmetatable( angle ) )
-                expect( isangle( fake_angle ) ).to.beFalse()
+                expect( isangle( angle ) ).to.beTrue()
+                expect( isangle( vector ) ).to.beFalse()
             end
         },
     }

--- a/lua/tests/gmod/globals/isangle.lua
+++ b/lua/tests/gmod/globals/isangle.lua
@@ -12,7 +12,7 @@ return {
             name = "Returns the right bool",
             func = function()
                 local angle = Angle( 1, 2, 3 )
-                expect( isangle( vector ) ).to.beTrue()
+                expect( isangle( angle ) ).to.beTrue()
 
                 local fake_angle = setmetatable( { p = 1, y = 2, r = 3 }, getmetatable( angle ) )
                 expect( isangle( fake_angle ) ).to.beFalse()

--- a/lua/tests/gmod/globals/isangle.lua
+++ b/lua/tests/gmod/globals/isangle.lua
@@ -1,0 +1,22 @@
+return {
+    groupName = "Global:isangle",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( isangle ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the right bool",
+            func = function()
+                local angle = Angle( 1, 2, 3 )
+                expect( isangle( vector ) ).to.beTrue()
+
+                local fake_angle = setmetatable( { p = 1, y = 2, r = 3 }, getmetatable( angle ) )
+                expect( isangle( fake_angle ) ).to.beFalse()
+            end
+        },
+    }
+}

--- a/lua/tests/gmod/globals/isvector.lua
+++ b/lua/tests/gmod/globals/isvector.lua
@@ -12,10 +12,10 @@ return {
             name = "Returns the right bool",
             func = function()
                 local vector = Vector( 1, 2, 3 )
-                expect( isvector( vector ) ).to.beTrue()
+                local angle = Angle( 1, 2, 3 )
 
-                local fake_vector = setmetatable( { x = 1, y = 2, z = 3 }, getmetatable( vector ) )
-                expect( isvector( fake_vector ) ).to.beFalse()
+                expect( isvector( vector ) ).to.beTrue()
+                expect( isvector( angle ) ).to.beFalse()
             end
         },
     }

--- a/lua/tests/gmod/globals/isvector.lua
+++ b/lua/tests/gmod/globals/isvector.lua
@@ -1,0 +1,22 @@
+return {
+    groupName = "Global:isvector",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( isvector ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the right bool",
+            func = function()
+                local vector = Vector( 1, 2, 3 )
+                expect( isvector( vector ) ).to.beTrue()
+
+                local fake_vector = setmetatable( { x = 1, y = 2, z = 3 }, getmetatable( vector ) )
+                expect( isvector( fake_vector ) ).to.beFalse()
+            end
+        },
+    }
+}


### PR DESCRIPTION
Adds tests for `VectorRand`, `Vector` and `isvector` with `isangle`. Vector test does almost the same thing as the Angle test, but (in my opinion) the code is cleaner. 

All tests were tested on the current `main` branch (2024.12.09), on `Windows 10 64x`
![image](https://github.com/user-attachments/assets/5e9f7994-c85b-4947-ac0b-1d6a347a9a51)