### PR TITLE
don't rely on float precision since it can cause issues

### DIFF
--- a/lua/tests/gmod/unit/classes/vector/Angle.lua
+++ b/lua/tests/gmod/unit/classes/vector/Angle.lua
@@ -17,8 +17,8 @@ return {
                 local a = Vector( 1, 2, 3 )
                 local b = a:Angle()
 
-                expect( b[1] ).to.equal( 306.69921875 )
-                expect( b[2] ).to.equal( 63.434947967529296875 )
+                expect( math.Round(b[1], 4) ).to.equal( math.Round(306.69921875, 4) )
+                expect( math.Round(b[2], 4) ).to.equal( math.Round(63.434947967529296875, 4) )
                 expect( b[3] ).to.equal( 0 )
             end
         },

--- a/lua/tests/gmod/unit/classes/vector/Angle.lua
+++ b/lua/tests/gmod/unit/classes/vector/Angle.lua
@@ -17,8 +17,8 @@ return {
                 local a = Vector( 1, 2, 3 )
                 local b = a:Angle()
 
-                expect( math.Round(b[1], 4) ).to.equal( math.Round(306.69921875, 4) )
-                expect( math.Round(b[2], 4) ).to.equal( math.Round(63.434947967529296875, 4) )
+                expect( b[1] ).to.aboutEqual( 306.69921  )
+                expect( b[2] ).to.aboutEqual( 63.43494 )
                 expect( b[3] ).to.equal( 0 )
             end
         },

--- a/lua/tests/gmod/unit/classes/vector/AngleEx.lua
+++ b/lua/tests/gmod/unit/classes/vector/AngleEx.lua
@@ -18,8 +18,8 @@ return {
                 local b = Vector( 0, 0, 1 )
                 local c = a:AngleEx( b )
 
-                expect( c[1] ).to.aboutEqual( -53.300769805908203125 )
-                expect( c[2] ).to.aboutEqual( 63.434947967529296875 )
+                expect( math.Round(c[1], 4) ).to.aboutEqual( math.Round(-53.300769805908203125, 4) )
+                expect( math.Round(c[2], 4) ).to.aboutEqual( math.Round(63.434947967529296875, 4) )
                 expect( c[3] ).to.equal( 0 )
             end
         },

--- a/lua/tests/gmod/unit/classes/vector/AngleEx.lua
+++ b/lua/tests/gmod/unit/classes/vector/AngleEx.lua
@@ -18,8 +18,8 @@ return {
                 local b = Vector( 0, 0, 1 )
                 local c = a:AngleEx( b )
 
-                expect( math.Round(c[1], 4) ).to.aboutEqual( math.Round(-53.300769805908203125, 4) )
-                expect( math.Round(c[2], 4) ).to.aboutEqual( math.Round(63.434947967529296875, 4) )
+                expect( c[1] ).to.aboutEqual( -53.30076 )
+                expect( c[2] ).to.aboutEqual( 63.43494 )
                 expect( c[3] ).to.equal( 0 )
             end
         },

--- a/lua/tests/gmod/unit/classes/vector/GetNormal.lua
+++ b/lua/tests/gmod/unit/classes/vector/GetNormal.lua
@@ -21,15 +21,9 @@ return {
                 expect( a[2] ).to.equal( 2 )
                 expect( a[3] ).to.equal( 3 )
 
-                if IS_64BIT_BRANCH then
-                	expect( b[1] ).to.equal( 0.2672612071037292480469 )
-                   	expect( b[2] ).to.equal( 0.5345224142074584960938 )
-                   	expect( b[3] ).to.equal( 0.8017836213111877441406 )
-                else
-               	   	expect( b[1] ).to.equal( 0.2672612369060516357422 )
-                   	expect( b[2] ).to.equal( 0.5345224738121032714844 )
-                   	expect( b[3] ).to.equal( 0.8017836809158325195312 )
-                end
+                expect( math.Round(b[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
+                expect( math.Round(b[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
+                expect( math.Round(b[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/GetNormal.lua
+++ b/lua/tests/gmod/unit/classes/vector/GetNormal.lua
@@ -21,9 +21,9 @@ return {
                 expect( a[2] ).to.equal( 2 )
                 expect( a[3] ).to.equal( 3 )
 
-                expect( math.Round(b[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
-                expect( math.Round(b[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
-                expect( math.Round(b[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
+                expect( b[1] ).to.aboutEqual( 0.26726  )
+                expect( b[2] ).to.aboutEqual( 0.53452 )
+                expect( b[3] ).to.aboutEqual( 0.80178 )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/GetNormalized.lua
+++ b/lua/tests/gmod/unit/classes/vector/GetNormalized.lua
@@ -21,15 +21,9 @@ return {
                 expect( a[2] ).to.equal( 2 )
                 expect( a[3] ).to.equal( 3 )
 
-                if IS_64BIT_BRANCH then
-                	expect( b[1] ).to.equal( 0.2672612071037292480469 )
-                   	expect( b[2] ).to.equal( 0.5345224142074584960938 )
-                   	expect( b[3] ).to.equal( 0.8017836213111877441406 )
-                else
-               	   	expect( b[1] ).to.equal( 0.2672612369060516357422 )
-                   	expect( b[2] ).to.equal( 0.5345224738121032714844 )
-                   	expect( b[3] ).to.equal( 0.8017836809158325195312 )
-                end
+               	expect( math.Round(b[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
+                expect( math.Round(b[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
+                expect( math.Round(b[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/GetNormalized.lua
+++ b/lua/tests/gmod/unit/classes/vector/GetNormalized.lua
@@ -21,9 +21,9 @@ return {
                 expect( a[2] ).to.equal( 2 )
                 expect( a[3] ).to.equal( 3 )
 
-               	expect( math.Round(b[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
-                expect( math.Round(b[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
-                expect( math.Round(b[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
+                expect( b[1] ).to.aboutEqual( 0.26726 )
+                expect( b[2] ).to.aboutEqual( 0.53452 )
+                expect( b[3] ).to.aboutEqual( 0.80178 )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/Normalize.lua
+++ b/lua/tests/gmod/unit/classes/vector/Normalize.lua
@@ -17,15 +17,9 @@ return {
                 local a = Vector( 1, 2, 3 )
                 a:Normalize()
 
-                if IS_64BIT_BRANCH then
-                	expect( a[1] ).to.equal( 0.2672612071037292480469 )
-                   	expect( a[2] ).to.equal( 0.5345224142074584960938 )
-                   	expect( a[3] ).to.equal( 0.8017836213111877441406 )
-                else
-               	   	expect( a[1] ).to.equal( 0.2672612369060516357422 )
-                   	expect( a[2] ).to.equal( 0.5345224738121032714844 )
-                   	expect( a[3] ).to.equal( 0.8017836809158325195312 )
-                end
+                expect( math.Round(a[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
+                expect( math.Round(a[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
+                expect( math.Round(a[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/Normalize.lua
+++ b/lua/tests/gmod/unit/classes/vector/Normalize.lua
@@ -17,9 +17,9 @@ return {
                 local a = Vector( 1, 2, 3 )
                 a:Normalize()
 
-                expect( math.Round(a[1], 5) ).to.equal( math.Round(0.2672612369060516357422, 5) )
-                expect( math.Round(a[2], 5) ).to.equal( math.Round(0.5345224738121032714844, 5) )
-                expect( math.Round(a[3], 5) ).to.equal( math.Round(0.8017836809158325195312, 5) )
+                expect( a[1] ).to.aboutEqual( 0.26726 )
+                expect( a[2] ).to.aboutEqual( 0.53452 )
+                expect( a[3] ).to.aboutEqual( 0.80178 )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/Rotate.lua
+++ b/lua/tests/gmod/unit/classes/vector/Rotate.lua
@@ -20,7 +20,7 @@ return {
 
                 expect( a[1] ).to.equal( 3 )
                 expect( a[2] ).to.equal( 2 )
-                expect( a[3] ).to.equal( -1.0000001192092895507812 )
+                expect( math.Round(a[3], 5) ).to.equal( math.Round(-1.0000001192092895507812, 5) )
             end
         },
     }

--- a/lua/tests/gmod/unit/classes/vector/Rotate.lua
+++ b/lua/tests/gmod/unit/classes/vector/Rotate.lua
@@ -20,7 +20,7 @@ return {
 
                 expect( a[1] ).to.equal( 3 )
                 expect( a[2] ).to.equal( 2 )
-                expect( math.Round(a[3], 5) ).to.equal( math.Round(-1.0000001192092895507812, 5) )
+                expect( a[3] ).to.aboutEqual( -1 )
             end
         },
     }


### PR DESCRIPTION
Different JIT versions (definitely will) & the CPU FPU could result in different results since they might handle floats differently since precision can differ. For Angle's we round to 4 digits, for Vector's we round to 5.
I had encountered this with HolyLib where with a newer JIT version, floats were handled differently when precision became an issue.