### PR TITLE
Import some HTTP tests

### DIFF
--- a/.github/workflows/branch_tests.yml
+++ b/.github/workflows/branch_tests.yml
@@ -131,8 +131,16 @@ jobs:
       map: gm_glua_tests
       branch: ${{ matrix.branch }}
       logs-as-artifact: true
-      extra-startup-args: "-maxplayers 64"
-      additional-setup: "cd project/.github/tools/ && chmod +x workshop_map.sh && ./workshop_map.sh"
+      extra-startup-args: "-maxplayers 64 -allowlocalhttp"
+      additional-setup: |
+        pushd project/.github/tools
+        chmod +x workshop_map.sh && ./workshop_map.sh
+        popd
+
+        # Start the testing server for the HTTP tests
+        sudo apt-get install -y python3-flask
+        ./project/lua/tests/gmod/unit/globals/HTTP.py 1>/dev/null 2>&1 &
+        until curl --silent "http://127.0.0.1:5000" 1>/dev/null 2>&1; do sleep 1; done
 
   summarize_failures:
       name: Summarize Failures

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,5 +28,13 @@ jobs:
     with:
       map: gm_glua_tests
       branch: ${{ matrix.branch }}
-      extra-startup-args: "-maxplayers 64"
-      additional-setup: "cd project/.github/tools/ && chmod +x workshop_map.sh && ./workshop_map.sh"
+      extra-startup-args: "-maxplayers 64 -allowlocalhttp"
+      additional-setup: |
+        pushd project/.github/tools
+        chmod +x workshop_map.sh && ./workshop_map.sh
+        popd
+
+        # Start the testing server for the HTTP tests
+        sudo apt-get install -y python3-flask
+        ./project/lua/tests/gmod/unit/globals/HTTP.py 1>/dev/null 2>&1 &
+        until curl --silent "http://127.0.0.1:5000" 1>/dev/null 2>&1; do sleep 1; done

--- a/lua/tests/gmod/unit/globals/HTTP.lua
+++ b/lua/tests/gmod/unit/globals/HTTP.lua
@@ -1,0 +1,296 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:HTTP",
+    cases = {
+        {
+            name = "Null bytes in response body are kept",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    url = "http://127.0.0.1:5000/response_null_byte_in_body",
+                    success = function(code, body, headers)
+                        expect(body).to.equal("Hello World\0!")
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Set-Cookie headers with same name are concatenated",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    url = "http://127.0.0.1:5000/response_multiple_cookies",
+                    success = function(code, body, headers)
+                        -- Note: RFC 6265 states that origin servers should not fold Set-Cookie
+                        --       headers due to semantics changes. This does not just apply to
+                        --       Cookies with Expires fields (as tested below).
+
+                        -- Header order is nondeterministic, so we need to test both combinations.
+                        expect((headers["Set-Cookie"] == "CookieA=1,CookieB=2") or (headers["Set-Cookie"] == "CookieB=2,CookieA=1")).to.beTrue()
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Set-Cookie headers with same name are concatenated even if invalid",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    url = "http://127.0.0.1:5000/response_multiple_cookies_with_expires",
+                    success = function(code, body, headers)
+
+                        -- Header order is nondeterministic, so we need to test both combinations.
+                        local cookie_a = "CookieA=1; Expires=Sat, 02 Feb 2002 12:17:00 GMT"
+                        local cookie_b = "CookieB=2; Expires=Fri, 21 Jul 2023 13:36:35 GMT"
+                        expect((headers["Set-Cookie"] == (cookie_a .. "," .. cookie_b)) or (headers["Set-Cookie"] == (cookie_b .. "," .. cookie_a))).to.beTrue()
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Headers with same name are concatenated",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    url = "http://127.0.0.1:5000/response_multiple_warning",
+                    success = function(code, body, headers)
+                        -- Header order is nondeterministic, so we need to test both combinations.
+                        local warning_a = "199 - Warning1"
+                        local warning_b = "199 - Warning2"
+                        expect((headers["Warning"] == (warning_a .. "," .. warning_b)) or (headers["Warning"] == (warning_b .. "," .. warning_a))).to.beTrue()
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Redirects are followed",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    url = "http://127.0.0.1:5000/response_redirect",
+                    success = function(code, body, headers)
+                        expect(code).to.equal(200)
+                        expect(body).to.equal("Redirected!")
+
+                        -- Let's make sure that headers from the redirection request are discarded.
+                        expect(headers["Location"]).to.beNil()
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Content-Type for GET request is unset by default",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    method = "GET",
+                    url = "http://127.0.0.1:5000/echo_content_type",
+                    success = function(code, body, headers)
+                        expect(code).to.equal(404)
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Content-Type for POST request defaults to urlencoded form",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    method = "POST",
+                    url = "http://127.0.0.1:5000/echo_content_type",
+                    success = function(code, body, headers)
+                        expect(body).to.equal("application/x-www-form-urlencoded")
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Content-Type for POST request with body defaults to plaintext",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    method = "POST",
+                    url = "http://127.0.0.1:5000/echo_content_type",
+                    body = "Hello world!",
+                    success = function(code, body, headers)
+                        expect(body).to.equal("text/plain; charset=utf-8")
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Content-Type for POST request with header override sticks",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    method = "POST",
+                    url = "http://127.0.0.1:5000/echo_content_type",
+                    headers = {
+                        ["Content-Type"] = "application/octet-stream",
+                    },
+                    success = function(code, body, headers)
+                        expect(body).to.equal("application/octet-stream")
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Content-Type for POST request with body and header override sticks",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    method = "POST",
+                    url = "http://127.0.0.1:5000/echo_content_type",
+                    headers = {
+                        ["Content-Type"] = "application/octet-stream",
+                    },
+                    body = "Hello world!",
+                    success = function(code, body, headers)
+                        expect(body).to.equal("application/octet-stream")
+                        done()
+                    end,
+                    failed = function(err)
+                        fail("HTTP request failed: " .. err)
+                    end
+                })
+            end
+        },
+        {
+            name = "Request methods are checked and translated",
+            async = true,
+            timeout = 1,
+            func = function()
+                -- We have to check multiple async requests, so we effectively implement something like a semaphore here.
+                -- We initialize to 1 and decrement once after all requests have been queued so we can reliably check at all exits.
+                local pending_requests = 1
+
+                local function on_request_done()
+                    pending_requests = pending_requests - 1
+                    if pending_requests == 0 then
+                        done()
+                    end
+                end
+
+                local function test_method(method_in, method_out)
+                    pending_requests = pending_requests + 1
+
+                    local queued = HTTP({
+                        method = method_in,
+                        url = "http://127.0.0.1:5000/echo_method",
+                        success = function(code, body, headers)
+                            expect(body).to.equal(method_out)
+                            on_request_done()
+                        end,
+                        failed = function(err)
+                            expect(err).to.equal("invalid method")
+                            on_request_done()
+                        end,
+                    })
+                    expect(queued).to.beTrue()
+                end
+
+                -- An unset method should default to GET
+                test_method(nil, "GET")
+
+                -- Request methods noted as supported in Structures/HTTPRequest
+                test_method("get", "GET")
+                test_method("GET", "GET")
+                test_method("post", "POST")
+                test_method("POST", "POST")
+                test_method("put", "PUT")
+                test_method("PUT", "PUT")
+                test_method("delete", "DELETE")
+                test_method("DELETE", "DELETE")
+                test_method("patch", "PATCH")
+                test_method("PATCH", "PATCH")
+                test_method("options", "OPTIONS")
+                test_method("OPTIONS", "OPTIONS")
+
+                -- HEAD is also one of those, but we don't get back the response body.
+                test_method("head", "")
+                test_method("HEAD", "")
+
+                -- Other request methods defined by RFC 9110, those are unsupported.
+                test_method("trace", nil)
+                test_method("TRACE", nil)
+                test_method("connect", nil)
+                test_method("CONNECT", nil)
+
+                -- All requests scheduled, check just in case the scheduler beat us every time.
+                -- That said, the way GLuaTest runs tests should make this impossible.
+                on_request_done()
+            end
+        },
+        {
+            name = "system.HTTPDisabled trick works",
+            func = function()
+                expect(HTTP({})).to.beTrue()
+            end
+        },
+        {
+            name = "Missing HTTPRequest throws error",
+            func = function()
+                expect(HTTP).to.err()
+            end
+        },
+        {
+            name = "Unset URL calls failure handler",
+            async = true,
+            timeout = 1,
+            func = function()
+                HTTP({
+                    failed = function(err)
+                        expect(err).to.equal("invalid url or GET parameters")
+                        done()
+                    end,
+                })
+            end
+        },
+    }
+}

--- a/lua/tests/gmod/unit/globals/HTTP.lua
+++ b/lua/tests/gmod/unit/globals/HTTP.lua
@@ -8,7 +8,7 @@ return {
             timeout = 1,
             func = function()
                 HTTP({
-                    url = "http://127.0.0.1:5000/response_null_byte_in_body",
+                    url = "http://172.17.0.1:5000/response_null_byte_in_body",
                     success = function(code, body, headers)
                         expect(body).to.equal("Hello World\0!")
                         done()
@@ -25,7 +25,7 @@ return {
             timeout = 1,
             func = function()
                 HTTP({
-                    url = "http://127.0.0.1:5000/response_multiple_cookies",
+                    url = "http://172.17.0.1:5000/response_multiple_cookies",
                     success = function(code, body, headers)
                         -- Note: RFC 6265 states that origin servers should not fold Set-Cookie
                         --       headers due to semantics changes. This does not just apply to
@@ -47,7 +47,7 @@ return {
             timeout = 1,
             func = function()
                 HTTP({
-                    url = "http://127.0.0.1:5000/response_multiple_cookies_with_expires",
+                    url = "http://172.17.0.1:5000/response_multiple_cookies_with_expires",
                     success = function(code, body, headers)
 
                         -- Header order is nondeterministic, so we need to test both combinations.
@@ -68,7 +68,7 @@ return {
             timeout = 1,
             func = function()
                 HTTP({
-                    url = "http://127.0.0.1:5000/response_multiple_warning",
+                    url = "http://172.17.0.1:5000/response_multiple_warning",
                     success = function(code, body, headers)
                         -- Header order is nondeterministic, so we need to test both combinations.
                         local warning_a = "199 - Warning1"
@@ -88,7 +88,7 @@ return {
             timeout = 1,
             func = function()
                 HTTP({
-                    url = "http://127.0.0.1:5000/response_redirect",
+                    url = "http://172.17.0.1:5000/response_redirect",
                     success = function(code, body, headers)
                         expect(code).to.equal(200)
                         expect(body).to.equal("Redirected!")
@@ -110,7 +110,7 @@ return {
             func = function()
                 HTTP({
                     method = "GET",
-                    url = "http://127.0.0.1:5000/echo_content_type",
+                    url = "http://172.17.0.1:5000/echo_content_type",
                     success = function(code, body, headers)
                         expect(code).to.equal(404)
                         done()
@@ -128,7 +128,7 @@ return {
             func = function()
                 HTTP({
                     method = "POST",
-                    url = "http://127.0.0.1:5000/echo_content_type",
+                    url = "http://172.17.0.1:5000/echo_content_type",
                     success = function(code, body, headers)
                         expect(body).to.equal("application/x-www-form-urlencoded")
                         done()
@@ -146,7 +146,7 @@ return {
             func = function()
                 HTTP({
                     method = "POST",
-                    url = "http://127.0.0.1:5000/echo_content_type",
+                    url = "http://172.17.0.1:5000/echo_content_type",
                     body = "Hello world!",
                     success = function(code, body, headers)
                         expect(body).to.equal("text/plain; charset=utf-8")
@@ -165,7 +165,7 @@ return {
             func = function()
                 HTTP({
                     method = "POST",
-                    url = "http://127.0.0.1:5000/echo_content_type",
+                    url = "http://172.17.0.1:5000/echo_content_type",
                     headers = {
                         ["Content-Type"] = "application/octet-stream",
                     },
@@ -186,7 +186,7 @@ return {
             func = function()
                 HTTP({
                     method = "POST",
-                    url = "http://127.0.0.1:5000/echo_content_type",
+                    url = "http://172.17.0.1:5000/echo_content_type",
                     headers = {
                         ["Content-Type"] = "application/octet-stream",
                     },
@@ -222,7 +222,7 @@ return {
 
                     local queued = HTTP({
                         method = method_in,
-                        url = "http://127.0.0.1:5000/echo_method",
+                        url = "http://172.17.0.1:5000/echo_method",
                         success = function(code, body, headers)
                             expect(body).to.equal(method_out)
                             on_request_done()

--- a/lua/tests/gmod/unit/globals/HTTP.lua
+++ b/lua/tests/gmod/unit/globals/HTTP.lua
@@ -122,7 +122,7 @@ return {
             end
         },
         {
-            name = "Content-Type for POST request defaults to urlencoded form",
+            name = "Content-Type for POST request defaults to being unset",
             async = true,
             timeout = 1,
             func = function()
@@ -130,7 +130,8 @@ return {
                     method = "POST",
                     url = "http://172.17.0.1:5000/echo_content_type",
                     success = function(code, body, headers)
-                        expect(body).to.equal("application/x-www-form-urlencoded")
+                        expect(code).to.equal(404)
+                        expect(body).to.equal("")
                         done()
                     end,
                     failed = function(err)
@@ -180,7 +181,7 @@ return {
             end
         },
         {
-            name = "Content-Type for POST request with body and header override sticks",
+            name = "Content-Type for POST request with body and header override does not stick",
             async = true,
             timeout = 1,
             func = function()
@@ -192,7 +193,7 @@ return {
                     },
                     body = "Hello world!",
                     success = function(code, body, headers)
-                        expect(body).to.equal("application/octet-stream")
+                        expect(body).to.equal("text/plain; charset=utf-8")
                         done()
                     end,
                     failed = function(err)
@@ -257,10 +258,10 @@ return {
                 test_method("HEAD", "")
 
                 -- Other request methods defined by RFC 9110, those are unsupported.
-                test_method("trace", nil)
-                test_method("TRACE", nil)
-                test_method("connect", nil)
-                test_method("CONNECT", nil)
+                test_method("trace", "INVALID")
+                test_method("TRACE", "INVALID")
+                test_method("connect", "INVALID")
+                test_method("CONNECT", "INVALID")
 
                 -- All requests scheduled, check just in case the scheduler beat us every time.
                 -- That said, the way GLuaTest runs tests should make this impossible.
@@ -286,7 +287,7 @@ return {
             func = function()
                 HTTP({
                     failed = function(err)
-                        expect(err).to.equal("invalid url or GET parameters")
+                        expect(err).to.equal("invalid url")
                         done()
                     end,
                 })

--- a/lua/tests/gmod/unit/globals/HTTP.py
+++ b/lua/tests/gmod/unit/globals/HTTP.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import flask
+
+app = flask.Flask(__name__)
+
+
+@app.route("/", methods=["GET"])
+def response_normal():
+    return b"Hello World!", 200
+
+
+@app.route("/echo_content_type", methods=["GET", "POST"])
+def echo_content_type():
+    if "Content-Type" not in flask.request.headers:
+        return b"", 404
+
+    return flask.request.headers["Content-Type"], 200
+
+
+@app.route("/echo_method", methods=["GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE", "POST", "PATCH", "CONNECT"])
+def echo_method():
+    return flask.request.method, 200
+
+
+@app.route("/response_null_byte_in_body", methods=["GET"])
+def response_null_byte_in_body():
+    return b"Hello World\0!", 200
+
+
+@app.route("/response_multiple_cookies", methods=["GET"])
+def response_multiple_cookies():
+    return (
+        b"Hello World!",
+        200,
+        {
+            "Set-Cookie": [
+                "CookieA=1",
+                "CookieB=2",
+            ],
+        },
+    )
+
+
+@app.route("/response_multiple_cookies_with_expires", methods=["GET"])
+def response_multiple_cookies_with_expires():
+    return (
+        b"Hello World!",
+        200,
+        {
+            "Set-Cookie": [
+                "CookieA=1; Expires=Sat, 02 Feb 2002 12:17:00 GMT",
+                "CookieB=2; Expires=Fri, 21 Jul 2023 13:36:35 GMT",
+            ],
+        },
+    )
+
+
+@app.route("/response_multiple_warning", methods=["GET"])
+def response_multiple_warning():
+    return (
+        b"Hello World!",
+        200,
+        {
+            "Warning": [
+                "199 - Warning1",
+                "199 - Warning2",
+            ],
+        },
+    )
+
+@app.route("/response_redirect", methods=["GET"])
+def response_redirect():
+    return (
+        b"Redirecting...",
+        307,
+        {
+            "Location": "/response_redirect_landing",
+        },
+    )
+
+@app.route("/response_redirect_landing", methods=["GET"])
+def response_redirect_landing():
+    return b"Redirected!", 200
+
+if __name__ == "__main__":
+    app.run(debug=False, host="0.0.0.0")

--- a/lua/tests/gmod/unit/globals/HTTP.py
+++ b/lua/tests/gmod/unit/globals/HTTP.py
@@ -18,7 +18,7 @@ def echo_content_type():
     return flask.request.headers["Content-Type"], 200
 
 
-@app.route("/echo_method", methods=["GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE", "POST", "PATCH", "CONNECT"])
+@app.route("/echo_method", methods=["GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE", "POST", "PATCH", "CONNECT", "INVALID"])
 def echo_method():
     return flask.request.method, 200
 


### PR DESCRIPTION
I have been writing behavior tests for HTTP while testing CHTTP, figured I might as well clean them up and import the tests that apply to both.

Draft until I figure out where I can start and kill the testing HTTP server.