### PR TITLE
More Globals + LLM Guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+gluatest-run.log

--- a/LLM_GUIDE.md
+++ b/LLM_GUIDE.md
@@ -1,0 +1,586 @@
+# Writing GLuaTest Tests
+
+GLuaTest is a testing framework for Garry's Mod Lua (GLua). This document is the complete reference for writing GLuaTest tests. It is authoritative: every field, function, and expectation that exists in GLuaTest is listed here. If a method is not in this document, it does not exist — do not use matchers or helpers from other frameworks (Jest, Busted, luassert, etc.). The only additions come from the project itself: shared helpers it defines under `lua/gluatest/extensions/`.
+
+Your job when writing tests: read the code under test first, then produce test files that follow this reference exactly.
+
+## Test files and discovery
+
+- Test files live at `lua/tests/<project>/` (any name for `<project>`, e.g. your addon's name). Subdirectories are scanned recursively; every `.lua` file found is loaded as one test group.
+- Files placed directly in `lua/tests/` (not inside a project folder) are **not** loaded.
+- Each test file must `return` a single test group table. A file whose returned table has no `cases` field is ignored with a warning. File-local helpers and constants above the `return` are fine.
+- Tests run **serverside**.
+
+Minimal runnable skeleton:
+
+```lua
+return {
+    groupName = "MyAddon: CalculateFallDamage",
+
+    cases = {
+        {
+            name = "Returns 0 for short falls",
+            func = function()
+                local damage = MyAddon.CalculateFallDamage( 10 )
+                expect( damage ).to.equal( 0 )
+            end
+        }
+    }
+}
+```
+
+## Test group fields
+
+This is the complete list of group fields:
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `cases` | table | yes | Array of test case tables |
+| `groupName` | string | no | Display name (defaults to the file path) |
+| `beforeAll` | `function( state )` | no | Runs once before the group; receives the group state |
+| `beforeEach` | `function( state )` | no | Runs before each case; receives that case's state |
+| `afterEach` | `function( state )` | no | Runs after each case, even if it failed |
+| `afterAll` | `function( state )` | no | Runs once after the group; receives the group state |
+
+## Test case fields
+
+This is the complete list of case fields:
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `name` | string | required | Human-readable description of the behavior |
+| `func` | `function( state )` | required | The test body |
+| `async` | boolean | `false` | Test finishes via `done()` / `fail()` instead of by returning |
+| `timeout` | number | `5` | Seconds before an async case fails with "Timeout" |
+| `coroutine` | boolean | `false` | Run the case inside a coroutine (it may yield) |
+| `cleanup` | `function( state )` | — | Runs after the case, **even if it failed or errored** |
+| `when` | boolean, function, or list of either | — | Case runs only if every condition is/returns `true` |
+| `skip` | boolean or function | — | Case is skipped if `true`/returns `true`; takes precedence over `when` |
+
+Notes:
+- `when = false` (or a function returning anything but `true`) skips the case. A list form is supported: `when = { system.IsLinux(), function() return game.IsDedicated() end }`.
+- A synchronous case that runs without ever calling `expect` is reported as **empty**, not passed. Async cases aren't flagged automatically, but the same rule applies: every case must assert something.
+
+## Expectations
+
+Assertions start with `expect( subject )` and chain through one of five links:
+
+- `.to` — positive assertion
+- `.notTo` / `.toNot` — negated assertion
+- `.was` / `.wasNot` — full aliases of `.to` / `.notTo`; by convention used for stub call checks (`expect( myStub ).was.called()`)
+
+This is the **complete** list of current expectation methods (two deprecated aliases are noted below). Anything else (`toBe`, `toEqual`, `toContain`, `contain`, `beCloseTo`, `toThrow`, `assert.are.equal`, ...) does not exist in GLuaTest.
+
+| Method | Passes when |
+|---|---|
+| `equal( value )` | `subject == value` (no deep comparison) |
+| `deepEqual( tbl )` | Tables are recursively equal (both must be tables) |
+| `aboutEqual( num, tolerance? )` | Difference ≤ tolerance (default `0.00001`); subject must be a number |
+| `beLessThan( num )` | `subject < num` |
+| `beGreaterThan( num )` | `subject > num` |
+| `beBetween( lower, upper )` | `lower <= subject <= upper` (inclusive) |
+| `beTrue()` / `beFalse()` | Subject is exactly `true` / exactly `false` |
+| `beValid()` / `beInvalid()` | `IsValid( subject )` passes / fails |
+| `beNil()` | Subject is `nil` |
+| `exist()` | Subject is not `nil` |
+| `beNaN()` | Subject is NaN; subject must be a number |
+| `beA( typeName )` / `beAn( typeName )` | `type( subject ) == typeName` (aliases) |
+| `succeed()` | Subject function runs without erroring |
+| `err()` | Subject function errors |
+| `errWith( message )` | Subject function errors with exactly `message` |
+| `called( n? )` | Subject stub was called at least once (or at least `n` times) |
+
+Semantics that matter:
+
+- **Function subjects**: for `succeed`, `err`, and `errWith`, pass the function *uncalled*, with its arguments as extra `expect` arguments:
+
+  ```lua
+  expect( MyAddon.Heal, ply, 50 ).to.succeed()          -- calls MyAddon.Heal( ply, 50 )
+  expect( MyAddon.Heal, nil ).to.errWith( "Expected a player, got nil" )
+  ```
+
+- `errWith` compares the exact error text after stripping the leading `path/to/file.lua:123:` prefix, so match the bare message. Engine errors need their full text, e.g. `"bad argument #1 to 'Heal' (Player expected, got nil)"`.
+- `expect( myStub ).was.called( 2 )` passes when the stub was called **at least** 2 times, not exactly 2.
+- The negated form `wasNot.called()` takes no count — it asserts zero calls.
+- Use `aboutEqual` or `beBetween` for float results; `equal` on floats is flaky.
+- In a synchronous case, a failed `expect` raises an error — **nothing after the failed line runs**. Put all teardown in `cleanup`, never at the bottom of `func`. (Async cases behave differently; see below.)
+- Deprecated, do not write in new tests: `.eq` (use `equal`) and `.haveBeenCalled` (use `.was.called`).
+
+## Stubs
+
+`stub( tbl, "key" )` replaces `tbl.key` with a callable stub and returns it. This is the complete stub API:
+
+```lua
+local s = stub( MyAddon, "GetRank" )          -- calls return nil until a behavior is set
+stub( MyAddon, "GetRank" ).returns( "admin" ) -- always returns these values (varargs allowed)
+stub( MyAddon, "GetRank" ).with( function( ply ) return ply.rank end ) -- delegate to a function
+stub( MyAddon, "GetRank" ).returnsSequence( { "user", "admin" }, "guest" ) -- nth call returns sequence[n]; the default is optional (nil when exhausted without one)
+local spy = stub()                             -- bare spy; replaces nothing, useful as a callback
+
+s.callCount                                    -- number of times the stub was called
+s.callHistory                                  -- array of argument lists, one per call
+s:Restore()                                    -- put the original function back early
+```
+
+- Each stub takes **one** behavior: `.returns`, `.with`, or `.returnsSequence` — setting a second errors ("Stub already set").
+- The key does not need to exist beforehand — stubbing a method the table never had works, and `Restore` sets it back to `nil`.
+- Inspect calls with `expect( s ).was.called()` / `expect( s ).wasNot.called()`. For an exact count, assert the field: `expect( s.callCount ).to.equal( 1 )`.
+- Stubs restore the original function **automatically after each case**, including stubs created in `beforeEach`. Call `s:Restore()` early only if the same test needs the real function back.
+
+## Async cases
+
+Set `async = true` when the behavior under test finishes later (timers, hooks, net callbacks). Two extra functions exist inside async cases only:
+
+- `done()` — marks the case finished.
+- `fail( reason? )` — immediately fails and finishes the case.
+
+Every path through an async case **must** end in exactly one `done()` or `fail()` call — otherwise the case hangs and fails with "Timeout" after `timeout` seconds.
+
+```lua
+{
+    name = "Regenerates health on the next think",
+    async = true,
+    timeout = 0.5, -- keep timeouts as low as reliably possible
+    func = function( state )
+        -- state.ply is created in the group's beforeEach (not shown)
+        hook.Add( "Think", "MyAddon_RegenTest", function()
+            hook.Remove( "Think", "MyAddon_RegenTest" ) -- stop re-firing before done() lands
+
+            local health = state.ply:Health()
+            expect( health ).to.beGreaterThan( 100 )
+
+            done()
+        end )
+    end
+}
+```
+
+Use `fail()` as a tripwire for code paths that must not run:
+
+```lua
+{
+    name = "Does not notify muted players",
+    async = true,
+    timeout = 0.5,
+    func = function()
+        local mutedPly = { muted = true, IsValid = function() return true end }
+
+        MyAddon.Notify( mutedPly, function()
+            fail( "The notify callback ran for a muted player" )
+        end )
+
+        timer.Simple( 0.2, function()
+            local sentCount = MyAddon.GetSentCount()
+            expect( sentCount ).to.equal( 0 )
+
+            done()
+        end )
+    end
+}
+```
+
+- Inside an async case, a failed `expect` is **recorded as the case's failure but does not abort execution** — the code after it keeps running. Still call `done()` after your expectations so the case ends immediately instead of waiting out the timeout.
+- A plain runtime error inside a timer/hook callback (not an `expect` failure) is not attributed to the case — it surfaces as a "Timeout". Keep callback bodies down to expectations plus `done()`.
+- Choose the smallest `timeout` that is reliable (0.1–1 for most timer/hook tests). The default is 5 seconds; a hung test holds up the whole run for that long.
+
+## Coroutine cases
+
+Set `coroutine = true` to run `func` inside a coroutine so it can `coroutine.yield()` mid-test. Combine it with `async = true` + `done()` so the `timeout` catches a coroutine that is never resumed. Capture the running coroutine and have outside code resume it:
+
+```lua
+{
+    name = "Finishes loading after one tick",
+    async = true,
+    coroutine = true,
+    timeout = 0.5,
+    func = function()
+        local co = coroutine.running()
+        timer.Simple( 0, function() coroutine.resume( co ) end )
+        coroutine.yield() -- suspends here until the timer resumes us
+
+        local loaded = MyAddon.IsLoaded()
+        expect( loaded ).to.beTrue()
+
+        done()
+    end
+}
+```
+
+GLuaTest ships no wait helpers — helpers like `WaitForTicks` only exist if the project defines them as extensions (see below).
+
+## What the framework cleans up for you — and what it doesn't
+
+After every case, GLuaTest automatically:
+
+- Removes any hooks added with `hook.Add` during the case
+- Removes any timers created with `timer.Create` / `timer.Simple` during the case
+- Restores all stubs
+
+Everything else leaks unless you undo it. Entities you spawn, files you write, globals or convars you change, net receivers you register — revert them in `cleanup` (per-case) or `afterEach` (whole group). Because a failed `expect` aborts a synchronous `func`, stash anything needing teardown on `state` the moment you create it, and do the teardown in `cleanup`:
+
+```lua
+{
+    name = "Applies damage to the target prop",
+    func = function( state )
+        local prop = ents.Create( "prop_physics" )
+        prop:Spawn()
+        state.prop = prop -- stash BEFORE asserting, so cleanup can always find it
+
+        MyAddon.Explode( prop:GetPos(), 10 )
+
+        local health = prop:Health()
+        expect( health ).to.beLessThan( 100 )
+    end,
+
+    cleanup = function( state )
+        if IsValid( state.prop ) then
+            SafeRemoveEntity( state.prop )
+        end
+    end
+}
+```
+
+## State
+
+Every case gets a fresh `state` table shared by `beforeEach`, `func`, `cleanup`, and `afterEach` for that case. Reads fall through to the group state (which `beforeAll`/`afterAll` receive), so values set in `beforeAll` are visible in every case, while writes inside a case stay isolated to that case.
+
+Use `state` for fixtures and for anything `cleanup` must undo. Do not pass data between cases — each case must work standing alone.
+
+## Designing good tests
+
+- **Test observable behavior**, one behavior per case: the return value, the entity change, the error raised. Don't test internals a caller can't see.
+- **Name cases as present-tense factual sentences** about behavior: `"Returns nil when the player is disconnected"`, `"Errors when given a negative amount"` — not `"test heal 1"`.
+- **Cover three kinds of cases** for each function: expected inputs, edge inputs (`nil`, `0`, negative, empty string/table, huge values), and failure paths asserted with `errWith` and the exact message.
+- **Research the function before writing cases**: look up the function's documentation first (for example via the gmodwiki MCP server, if available) and turn every Warning, Note, Bug, or deprecation callout into a test case or a documented decision to skip it — realm differences, entities that are invalid for a tick after creation, functions that silently no-op on bad input, prediction quirks. The docs' notes sections are where GMod's divergences from stock Lua and other surprises live.
+- **Probe for unexpected behavior**: don't assume a function matches stock Lua or its own documentation. GMod overrides many builtins (e.g. `type` is a Lua function that no longer errors on missing arguments), and engine functions have quirks the docs may not mention: returning `nil` instead of erroring, silent no-ops on invalid entities, case-sensitivity, string trimming, numeric precision, and behavior at exact boundaries (`0`, the documented max, one past it). When a test fails against your expectation, first consider that the *engine's actual behavior* is the fact to pin down — write the case to assert what GMod really does, named after the surprise.
+- **Split work into intentional steps**: call the function under test, assign the result to a named local, then assert the local. Don't bury the call inside `expect( ... )`:
+
+  ```lua
+  local price = PointShop.CalculatePrice( 100, "member" )
+  expect( price ).to.equal( 90 )
+  ```
+
+- **No loops or metaprogramming in cases**: write each input's case or assertion out explicitly, even when repetitive — explicit tests read clearly and fail clearly.
+- **Isolate the unit with stubs**: stub out expensive or unrelated dependencies (network, database, chat output) so the test exercises only the function under test.
+- **Prefer fake entity tables over real entities**: when the code under test only calls methods on an entity, hand it a plain table faking exactly those methods — no spawning, no cleanup, no engine flakiness. If the code calls `IsValid( target )`, include an `IsValid` method on the fake. Create a real entity only when engine behavior matters (spawning, physics, damage, networking):
+
+  ```lua
+  local fakePly = {
+      Nick = function() return "Fake Player" end,
+      IsPlayer = function() return true end,
+      IsValid = function() return true end
+  }
+
+  local message = MyAddon.FormatJoinMessage( fakePly )
+  expect( message ).to.equal( "Fake Player joined!" )
+  ```
+
+- **Use bots when a real player is unavoidable**: `player.CreateNextBot( name )` gives a real player entity serverside. Never rely on connected humans. Kick bots in `cleanup`.
+- **Guard every entity teardown**: `if IsValid( state.ent ) then SafeRemoveEntity( state.ent ) end`.
+- **Gate environment-dependent cases with `when`** (map, OS, player count) instead of letting them fail.
+- **Prefer sync tests**: only use `async` when the code path is genuinely asynchronous.
+- **Check for project extensions**: projects can define shared helpers in `lua/gluatest/extensions/`. Reuse the project's existing helpers and conventions; never invent a helper that isn't in this document or in that folder.
+- **Code style**: 4-space indent, double quotes, spaces inside parentheses — `expect( x ).to.equal( y )`, `func = function( state )`. Empty parentheses stay empty: `done()`, `beTrue()`.
+- **Vertical spacing**: a blank line between every case in `cases`; inside a case, a blank line after each multi-line function value that has another key after it (e.g. after `func = ... end,` when `cleanup` follows); a blank line before the final `done()` in async callbacks.
+
+## Workflow
+
+1. Read the code under test. List its public functions and, for each, the behaviors a caller relies on. For GMod engine functions, look up the documentation first and collect its warnings, notes, and edge cases — each one is a candidate test case.
+2. Locate or create the test file: `lua/tests/<project>/<module>.lua`, one focused group per file.
+3. Write one case per behavior: expected, edge, and error cases.
+4. Make each case self-contained: fixtures in `beforeEach`/`state`, teardown of entities/files/globals in `cleanup`.
+5. Use `async` + `done()` + a tight `timeout` only where the code is actually asynchronous.
+6. Before finishing, verify every field and expectation you wrote appears in the tables above, and that every case calls `expect`.
+7. If Docker is available, prove the suite passes by running it (see "Running your tests" below). Reading tests is not running them: a real run catches load errors, typo'd expectation names, async cases that never call `done()`, and behavior you guessed wrong.
+
+## Running your tests
+
+GLuaTest ships a local runner that boots a real GMod server in Docker and runs the suite — the same runner CI uses. Clone the GLuaTest repo if you don't have it, then run from the project you're testing:
+
+```sh
+cd /path/to/your/project
+/path/to/GLuaTest/docker/run_local.sh --quiet
+```
+
+- Always pass `--quiet`: the live server stream is thousands of lines. You still get progress notes and the verdict. Use `--project /path/to/project` to run from elsewhere.
+- **Exit code is the verdict:** `0` = every test passed. `124` = the server hit the time limit before finishing — retry with `--timeout 5`. Anything else = a test failed or the server crashed.
+- Every run writes the complete server log to `gluatest-run.log` in the directory you invoked from. Do not read it whole (it contains the full server boot); search it: `FAIL` marks failed cases and `Test failures:` heads the failure detail section with stack traces.
+- On Apple Silicon hosts add `--branch x86-64` — the default branch's 32-bit server crashes under emulation.
+- The first run downloads a multi-gigabyte server image and is slow; later runs reuse it. If your project needs other addons, list them in `gluatest_requirements.txt` (`Owner/Repo` per line) in the project root — the runner picks it up automatically.
+
+## Worked examples
+
+A complete file — pure-function group with edge and error cases:
+
+```lua
+return {
+    groupName = "PointShop: CalculatePrice",
+
+    cases = {
+        {
+            name = "Applies the member discount",
+            func = function()
+                local price = PointShop.CalculatePrice( 100, "member" )
+                expect( price ).to.equal( 90 )
+            end
+        },
+
+        {
+            name = "Applies fractional discounts within rounding tolerance",
+            func = function()
+                local price = PointShop.CalculatePrice( 99.99, "member" )
+                expect( price ).to.aboutEqual( 89.99, 0.01 )
+            end
+        },
+
+        {
+            name = "Charges guests full price",
+            func = function()
+                local price = PointShop.CalculatePrice( 100, "guest" )
+                expect( price ).to.equal( 100 )
+            end
+        },
+
+        {
+            name = "Returns 0 for a free item regardless of rank",
+            func = function()
+                local price = PointShop.CalculatePrice( 0, "admin" )
+                expect( price ).to.equal( 0 )
+            end
+        },
+
+        {
+            name = "Errors when given a negative base price",
+            func = function()
+                expect( PointShop.CalculatePrice, -5, "member" ).to.errWith( "price must be >= 0" )
+            end
+        }
+    }
+}
+```
+
+Entity fixture via `beforeEach`, extra resources cleaned per-case:
+
+```lua
+return {
+    groupName = "FortWars: Ownership",
+
+    beforeEach = function( state )
+        local prop = ents.Create( "prop_physics" )
+        prop:SetModel( "models/props_c17/oildrum001.mdl" )
+        prop:Spawn()
+        state.prop = prop
+    end,
+
+    afterEach = function( state )
+        if IsValid( state.prop ) then
+            SafeRemoveEntity( state.prop )
+        end
+    end,
+
+    cases = {
+        {
+            name = "Marks the spawner as the owner",
+            func = function( state )
+                local bot = player.CreateNextBot( "fortwars_test_bot" )
+                state.bot = bot
+
+                FortWars.SetOwner( state.prop, bot )
+
+                local owner = FortWars.GetOwner( state.prop )
+                expect( owner ).to.equal( bot )
+            end,
+
+            cleanup = function( state )
+                if IsValid( state.bot ) then
+                    state.bot:Kick( "Test finished" )
+                end
+            end
+        },
+
+        {
+            name = "Returns nil for unowned props",
+            func = function( state )
+                local owner = FortWars.GetOwner( state.prop )
+                expect( owner ).to.beNil()
+            end
+        }
+    }
+}
+```
+
+Stub-isolated logic with a fake player and a globals-restoring `cleanup`:
+
+```lua
+return {
+    groupName = "DailyRewards: Grant",
+
+    beforeEach = function( state )
+        -- Grant only reads identity methods, so a fake player table is enough
+        state.fakePly = {
+            SteamID = function() return "STEAM_0:1:11111" end,
+            IsPlayer = function() return true end,
+            IsValid = function() return true end
+        }
+    end,
+
+    cases = {
+        {
+            name = "Saves through the storage layer exactly once",
+            func = function( state )
+                local save = stub( DailyRewards.Storage, "Save" ).returns( true )
+
+                DailyRewards.Grant( state.fakePly, 500 )
+
+                expect( save.callCount ).to.equal( 1 )
+            end
+        },
+
+        {
+            name = "Skips players who already claimed today",
+            func = function( state )
+                stub( DailyRewards.Storage, "HasClaimed" ).returns( true )
+                local save = stub( DailyRewards.Storage, "Save" )
+
+                state.originalCooldown = DailyRewards.Cooldown
+                DailyRewards.Cooldown = 0 -- globals aren't auto-restored; stash the original
+
+                DailyRewards.Grant( state.fakePly, 500 )
+
+                expect( save ).wasNot.called()
+            end,
+
+            cleanup = function( state )
+                DailyRewards.Cooldown = state.originalCooldown
+            end
+        }
+    }
+}
+```
+
+Async timer behavior with a `when`-gated case:
+
+```lua
+return {
+    groupName = "JailBreak: RoundTimer",
+
+    cases = {
+        {
+            name = "Fires the round-end callback after the duration",
+            async = true,
+            timeout = 0.5,
+            func = function()
+                local onEnd = stub()
+
+                JailBreak.StartRound( 0.1, onEnd )
+
+                timer.Simple( 0.2, function()
+                    expect( onEnd ).was.called()
+
+                    done()
+                end )
+            end
+        },
+
+        {
+            name = "Counts every connected player into the round",
+            when = function() return #player.GetHumans() == 0 end, -- needs a bot-only server
+            func = function( state )
+                local bot = player.CreateNextBot( "jb_test_bot" )
+                state.bot = bot
+
+                JailBreak.StartRound( 10 )
+
+                local playerCount = JailBreak.GetRoundPlayerCount()
+                expect( playerCount ).to.equal( 1 )
+            end,
+
+            cleanup = function( state )
+                JailBreak.EndRound()
+
+                if IsValid( state.bot ) then
+                    state.bot:Kick( "Test finished" )
+                end
+            end
+        }
+    }
+}
+```
+
+## Common mistakes
+
+**Teardown at the bottom of `func`** — a failed `expect` aborts `func`, so teardown there never runs and state leaks into other tests:
+
+```lua
+-- WRONG
+func = function()
+    OldValue = MyAddon.MaxHealth
+    MyAddon.MaxHealth = 50
+    expect( MyAddon.GetMaxHealth() ).to.equal( 50 )
+    MyAddon.MaxHealth = OldValue -- skipped if the expect fails
+end
+
+-- RIGHT: cleanup always runs, even on failure
+func = function( state )
+    state.oldValue = MyAddon.MaxHealth
+    MyAddon.MaxHealth = 50
+
+    local maxHealth = MyAddon.GetMaxHealth()
+    expect( maxHealth ).to.equal( 50 )
+end,
+
+cleanup = function( state )
+    MyAddon.MaxHealth = state.oldValue
+end
+```
+
+**Async case that never calls `done()`** — the case hangs until the timeout and then fails, even though its expectations passed:
+
+```lua
+-- WRONG
+async = true,
+func = function()
+    timer.Simple( 0.1, function()
+        expect( MyAddon.IsReady() ).to.beTrue()
+        -- missing done()
+    end )
+end
+
+-- RIGHT: done() after the expectations, timeout kept tight
+async = true,
+timeout = 0.5,
+func = function()
+    timer.Simple( 0.1, function()
+        local ready = MyAddon.IsReady()
+        expect( ready ).to.beTrue()
+
+        done()
+    end )
+end
+```
+
+**Matchers borrowed from other frameworks** — they don't exist here and error immediately:
+
+```lua
+-- WRONG
+expect( result ).to.toBe( 5 )
+expect( list ).to.contain( "admin" )
+
+-- RIGHT: use the GLuaTest expectation table
+expect( result ).to.equal( 5 )
+
+local hasAdmin = table.HasValue( list, "admin" )
+expect( hasAdmin ).to.beTrue()
+
+expect( list ).to.deepEqual( { "admin" } )
+```
+
+## Critical reminders
+
+- Use only the fields, expectations, and stub methods listed in this document, plus helpers the project itself defines under `lua/gluatest/extensions/` — nothing else exists.
+- Teardown goes in `cleanup` (or `afterEach`), never at the end of `func`; stash handles on `state` as soon as you create them.
+- Async cases must set `async = true`, end every path with `done()` or `fail()`, and use the lowest reliable `timeout` (default is 5s).
+- Hooks, timers, and stubs are cleaned up automatically after each case (still `hook.Remove` a repeating hook once it has served its purpose); entities, files, globals, and convars are yours to revert.
+- Every case must call `expect` at least once, and files must live at `lua/tests/<project>/`.
+- Write tests explicitly and intentionally: assign results to locals before asserting, no loops over inputs, blank lines between cases and after multi-line function values.
+- Match the code style: spaces inside parentheses, double quotes, 4-space indent.

--- a/lua/tests/gmod/unit/globals/ipairs.lua
+++ b/lua/tests/gmod/unit/globals/ipairs.lua
@@ -1,0 +1,72 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:ipairs",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( ipairs ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Iterates sequential elements in order",
+            func = function()
+                local visited = {}
+                for index, value in ipairs( { "a", "b", "c" } ) do
+                    table.insert( visited, { index, value } )
+                end
+
+                expect( visited ).to.deepEqual( { { 1, "a" }, { 2, "b" }, { 3, "c" } } )
+            end
+        },
+
+        {
+            name = "Stops at the first nil element",
+            func = function()
+                local input = { 1, 2, nil, 4 }
+
+                local count = 0
+                for _ in ipairs( input ) do
+                    count = count + 1
+                end
+
+                expect( count ).to.equal( 2 )
+            end
+        },
+
+        {
+            name = "Does not visit non-sequential keys",
+            func = function()
+                local input = { "first", key = "value" }
+
+                local count = 0
+                for _ in ipairs( input ) do
+                    count = count + 1
+                end
+
+                expect( count ).to.equal( 1 )
+            end
+        },
+
+        {
+            name = "Never runs the loop body for an empty table",
+            func = function()
+                local ran = false
+                for _ in ipairs( {} ) do
+                    ran = true
+                end
+
+                expect( ran ).to.beFalse()
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( function() ipairs( nil ) end ).to.errWith( [[bad argument #1 to 'ipairs' (table expected, got nil)]] )
+                expect( function() ipairs( 5 ) end ).to.errWith( [[bad argument #1 to 'ipairs' (table expected, got number)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/next.lua
+++ b/lua/tests/gmod/unit/globals/next.lua
@@ -1,0 +1,73 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:next",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( next ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the first key and value of a table",
+            func = function()
+                local key, value = next( { onlyKey = "onlyValue" } )
+
+                expect( key ).to.equal( "onlyKey" )
+                expect( value ).to.equal( "onlyValue" )
+            end
+        },
+
+        {
+            name = "Returns nil for an empty table",
+            func = function()
+                local key = next( {} )
+                expect( key ).to.beNil()
+            end
+        },
+
+        {
+            name = "Returns the next key and value when given a previous key",
+            func = function()
+                local key, value = next( { "a", "b" }, 1 )
+
+                expect( key ).to.equal( 2 )
+                expect( value ).to.equal( "b" )
+            end
+        },
+
+        {
+            name = "Returns nil when given the last key",
+            func = function()
+                local key = next( { "a" }, 1 )
+                expect( key ).to.beNil()
+            end
+        },
+
+        {
+            name = "Visits every key exactly once when used to iterate",
+            func = function()
+                local input = { alpha = 1, bravo = 2, charlie = 3 }
+
+                local seen = {}
+                local key, value = next( input )
+                while key ~= nil do
+                    seen[key] = value
+                    key, value = next( input, key )
+                end
+
+                expect( seen ).to.deepEqual( { alpha = 1, bravo = 2, charlie = 3 } )
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( function() next( 5 ) end ).to.errWith( [[bad argument #1 to 'next' (table expected, got number)]] )
+                expect( function() next( "abc" ) end ).to.errWith( [[bad argument #1 to 'next' (table expected, got string)]] )
+                expect( function() next( nil ) end ).to.errWith( [[bad argument #1 to 'next' (table expected, got nil)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/pairs.lua
+++ b/lua/tests/gmod/unit/globals/pairs.lua
@@ -1,0 +1,72 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:pairs",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( pairs ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Visits every key-value pair exactly once",
+            func = function()
+                local input = { a = 1, b = 2, c = 3 }
+
+                local seen = {}
+                for key, value in pairs( input ) do
+                    seen[key] = value
+                end
+
+                expect( seen ).to.deepEqual( { a = 1, b = 2, c = 3 } )
+            end
+        },
+
+        {
+            name = "Visits both array and hash keys",
+            func = function()
+                local input = { "first", extra = "second" }
+
+                local seen = {}
+                for key, value in pairs( input ) do
+                    seen[key] = value
+                end
+
+                expect( seen ).to.deepEqual( { "first", extra = "second" } )
+            end
+        },
+
+        {
+            name = "Never runs the loop body for an empty table",
+            func = function()
+                local ran = false
+                for _ in pairs( {} ) do
+                    ran = true
+                end
+
+                expect( ran ).to.beFalse()
+            end
+        },
+
+        {
+            name = "Returns an iterator function, the table, and nil",
+            func = function()
+                local input = { key = "value" }
+                local iterator, tbl, startKey = pairs( input )
+
+                expect( iterator ).to.beA( "function" )
+                expect( tbl ).to.equal( input )
+                expect( startKey ).to.beNil()
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( function() pairs( 5 ) end ).to.errWith( [[bad argument #1 to 'pairs' (table expected, got number)]] )
+                expect( function() pairs( nil ) end ).to.errWith( [[bad argument #1 to 'pairs' (table expected, got nil)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/pcall.lua
+++ b/lua/tests/gmod/unit/globals/pcall.lua
@@ -1,0 +1,109 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:pcall",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( pcall ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns true and the return values when the function succeeds",
+            func = function()
+                local func = function()
+                    return 1, "two"
+                end
+
+                local ok, first, second = pcall( func )
+
+                expect( ok ).to.beTrue()
+                expect( first ).to.equal( 1 )
+                expect( second ).to.equal( "two" )
+            end
+        },
+
+        {
+            name = "Passes arguments through to the called function",
+            func = function()
+                local func = function( a, b )
+                    return a + b
+                end
+
+                local ok, sum = pcall( func, 3, 4 )
+
+                expect( ok ).to.beTrue()
+                expect( sum ).to.equal( 7 )
+            end
+        },
+
+        {
+            name = "Returns false and the error message when the function errors",
+            func = function()
+                local func = function()
+                    error( "pcall test error", 0 )
+                end
+
+                local ok, err = pcall( func )
+
+                expect( ok ).to.beFalse()
+                expect( err ).to.equal( "pcall test error" )
+            end
+        },
+
+        {
+            name = "Prefixes thrown string errors with the file and line",
+            func = function()
+                local func = function()
+                    error( "prefixed error" )
+                end
+
+                local ok, err = pcall( func )
+                expect( ok ).to.beFalse()
+
+                local hasPrefix = string.find( err, "%.lua:%d+: prefixed error$" ) ~= nil
+                expect( hasPrefix ).to.beTrue()
+            end
+        },
+
+        {
+            name = "Preserves non-string error values",
+            func = function()
+                local errValue = { code = 42 }
+                local func = function()
+                    error( errValue )
+                end
+
+                local ok, err = pcall( func )
+
+                expect( ok ).to.beFalse()
+                expect( err ).to.equal( errValue )
+            end
+        },
+
+        {
+            name = "Returns false when given a non-function",
+            func = function()
+                local ok, err = pcall( "not a function" )
+
+                expect( ok ).to.beFalse()
+                expect( err ).to.equal( "attempt to call a string value" )
+            end
+        },
+
+        {
+            name = "Catches runtime errors from invalid operations",
+            func = function()
+                local func = function()
+                    return nil + 1
+                end
+
+                local ok, err = pcall( func )
+
+                expect( ok ).to.beFalse()
+                expect( err ).to.beA( "string" )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/rawequal.lua
+++ b/lua/tests/gmod/unit/globals/rawequal.lua
@@ -1,0 +1,65 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:rawequal",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( rawequal ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns true when given the same table twice",
+            func = function()
+                local tbl = {}
+                local result = rawequal( tbl, tbl )
+
+                expect( result ).to.beTrue()
+            end
+        },
+
+        {
+            name = "Returns false for distinct tables with equal contents",
+            func = function()
+                local result = rawequal( { 1 }, { 1 } )
+                expect( result ).to.beFalse()
+            end
+        },
+
+        {
+            name = "Returns true for equal primitive values",
+            func = function()
+                expect( rawequal( 1, 1 ) ).to.beTrue()
+                expect( rawequal( "a", "a" ) ).to.beTrue()
+                expect( rawequal( true, true ) ).to.beTrue()
+                expect( rawequal( nil, nil ) ).to.beTrue()
+            end
+        },
+
+        {
+            name = "Returns false for values of different types",
+            func = function()
+                expect( rawequal( 1, "1" ) ).to.beFalse()
+                expect( rawequal( false, nil ) ).to.beFalse()
+            end
+        },
+
+        {
+            name = "Ignores the __eq metamethod",
+            func = function()
+                local meta = {
+                    __eq = function() return true end
+                }
+
+                local a = setmetatable( {}, meta )
+                local b = setmetatable( {}, meta )
+
+                expect( a == b ).to.beTrue()
+
+                local rawResult = rawequal( a, b )
+                expect( rawResult ).to.beFalse()
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/rawget.lua
+++ b/lua/tests/gmod/unit/globals/rawget.lua
@@ -1,0 +1,50 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:rawget",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( rawget ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the value stored at the given key",
+            func = function()
+                local value = rawget( { key = "value" }, "key" )
+                expect( value ).to.equal( "value" )
+            end
+        },
+
+        {
+            name = "Returns nil for a missing key",
+            func = function()
+                local value = rawget( {}, "missing" )
+                expect( value ).to.beNil()
+            end
+        },
+
+        {
+            name = "Ignores the __index metamethod",
+            func = function()
+                local tbl = setmetatable( {}, {
+                    __index = function() return "from metamethod" end
+                } )
+
+                expect( tbl.missing ).to.equal( "from metamethod" )
+
+                local rawValue = rawget( tbl, "missing" )
+                expect( rawValue ).to.beNil()
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( rawget, 5, "key" ).to.errWith( [[bad argument #1 to '?' (table expected, got number)]] )
+                expect( rawget, "abc", "key" ).to.errWith( [[bad argument #1 to '?' (table expected, got string)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/rawset.lua
+++ b/lua/tests/gmod/unit/globals/rawset.lua
@@ -1,0 +1,56 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:rawset",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( rawset ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Sets the value at the given key",
+            func = function()
+                local tbl = {}
+                rawset( tbl, "key", "value" )
+
+                expect( tbl.key ).to.equal( "value" )
+            end
+        },
+
+        {
+            name = "Returns the table it modified",
+            func = function()
+                local tbl = {}
+                local returned = rawset( tbl, "key", "value" )
+
+                expect( returned ).to.equal( tbl )
+            end
+        },
+
+        {
+            name = "Ignores the __newindex metamethod",
+            func = function()
+                local metamethodRan = false
+
+                local tbl = setmetatable( {}, {
+                    __newindex = function() metamethodRan = true end
+                } )
+
+                rawset( tbl, "key", "value" )
+
+                expect( metamethodRan ).to.beFalse()
+                expect( tbl.key ).to.equal( "value" )
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( rawset, 5, "key", "value" ).to.errWith( [[bad argument #1 to '?' (table expected, got number)]] )
+                expect( rawset, "abc", "key", "value" ).to.errWith( [[bad argument #1 to '?' (table expected, got string)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/select.lua
+++ b/lua/tests/gmod/unit/globals/select.lua
@@ -1,0 +1,61 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:select",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( select ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the number of arguments when given '#'",
+            func = function()
+                local count = select( "#", "a", "b", "c" )
+                expect( count ).to.equal( 3 )
+            end
+        },
+
+        {
+            name = "Counts nil arguments in '#' mode",
+            func = function()
+                local count = select( "#", nil, nil, nil )
+                expect( count ).to.equal( 3 )
+            end
+        },
+
+        {
+            name = "Returns zero when given '#' and no arguments",
+            func = function()
+                local count = select( "#" )
+                expect( count ).to.equal( 0 )
+            end
+        },
+
+        {
+            name = "Returns all arguments starting from the given index",
+            func = function()
+                local second, third = select( 2, "a", "b", "c" )
+
+                expect( second ).to.equal( "b" )
+                expect( third ).to.equal( "c" )
+            end
+        },
+
+        {
+            name = "Returns nothing when the index is past the argument count",
+            func = function()
+                local count = select( "#", select( 4, "a", "b", "c" ) )
+                expect( count ).to.equal( 0 )
+            end
+        },
+
+        {
+            name = "Errors when the index is zero",
+            func = function()
+                expect( select, 0, "a" ).to.errWith( [[bad argument #1 to '?' (index out of range)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/tonumber.lua
+++ b/lua/tests/gmod/unit/globals/tonumber.lua
@@ -1,0 +1,74 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:tonumber",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( tonumber ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Converts numeric strings to numbers",
+            func = function()
+                expect( tonumber( "42" ) ).to.equal( 42 )
+                expect( tonumber( "-7" ) ).to.equal( -7 )
+                expect( tonumber( "1.5" ) ).to.equal( 1.5 )
+                expect( tonumber( "1e2" ) ).to.equal( 100 )
+            end
+        },
+
+        {
+            name = "Passes numbers through unchanged",
+            func = function()
+                expect( tonumber( 10 ) ).to.equal( 10 )
+                expect( tonumber( -1.5 ) ).to.equal( -1.5 )
+            end
+        },
+
+        {
+            name = "Ignores surrounding whitespace",
+            func = function()
+                local value = tonumber( "  42  " )
+                expect( value ).to.equal( 42 )
+            end
+        },
+
+        {
+            name = "Converts hexadecimal strings",
+            func = function()
+                expect( tonumber( "0x10" ) ).to.equal( 16 )
+                expect( tonumber( "0XFF" ) ).to.equal( 255 )
+            end
+        },
+
+        {
+            name = "Converts strings using the given base",
+            func = function()
+                expect( tonumber( "ff", 16 ) ).to.equal( 255 )
+                expect( tonumber( "10", 2 ) ).to.equal( 2 )
+                expect( tonumber( "z", 36 ) ).to.equal( 35 )
+            end
+        },
+
+        {
+            name = "Returns nil for values that cannot be converted",
+            func = function()
+                expect( tonumber( "abc" ) ).to.beNil()
+                expect( tonumber( "" ) ).to.beNil()
+                expect( tonumber( {} ) ).to.beNil()
+                expect( tonumber( true ) ).to.beNil()
+                expect( tonumber( nil ) ).to.beNil()
+            end
+        },
+
+        {
+            name = "Returns nil for digits outside the given base",
+            func = function()
+                local value = tonumber( "2", 2 )
+                expect( value ).to.beNil()
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/tostring.lua
+++ b/lua/tests/gmod/unit/globals/tostring.lua
@@ -1,0 +1,60 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:tostring",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( tostring ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Converts primitive values to strings",
+            func = function()
+                expect( tostring( 42 ) ).to.equal( "42" )
+                expect( tostring( 1.5 ) ).to.equal( "1.5" )
+                expect( tostring( true ) ).to.equal( "true" )
+                expect( tostring( false ) ).to.equal( "false" )
+                expect( tostring( nil ) ).to.equal( "nil" )
+            end
+        },
+
+        {
+            name = "Passes strings through unchanged",
+            func = function()
+                local value = tostring( "already a string" )
+                expect( value ).to.equal( "already a string" )
+            end
+        },
+
+        {
+            name = "Uses the __tostring metamethod when present",
+            func = function()
+                local tbl = setmetatable( {}, {
+                    __tostring = function() return "custom string" end
+                } )
+
+                local value = tostring( tbl )
+                expect( value ).to.equal( "custom string" )
+            end
+        },
+
+        {
+            name = "Formats plain tables with a table prefix",
+            func = function()
+                local value = tostring( {} )
+
+                local prefix = string.sub( value, 1, 7 )
+                expect( prefix ).to.equal( "table: " )
+            end
+        },
+
+        {
+            name = "Errors when called with no arguments",
+            func = function()
+                expect( tostring ).to.errWith( [[bad argument #1 to '?' (value expected)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/type.lua
+++ b/lua/tests/gmod/unit/globals/type.lua
@@ -1,0 +1,49 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:type",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( type ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns the correct name for primitive types",
+            func = function()
+                expect( type( 1 ) ).to.equal( "number" )
+                expect( type( "a" ) ).to.equal( "string" )
+                expect( type( true ) ).to.equal( "boolean" )
+                expect( type( nil ) ).to.equal( "nil" )
+                expect( type( {} ) ).to.equal( "table" )
+                expect( type( print ) ).to.equal( "function" )
+            end
+        },
+
+        {
+            name = "Returns thread for coroutines",
+            func = function()
+                local co = coroutine.create( function() end )
+                local typeName = type( co )
+
+                expect( typeName ).to.equal( "thread" )
+            end
+        },
+
+        {
+            name = "Returns GMod type names for GMod objects",
+            func = function()
+                expect( type( Vector() ) ).to.equal( "Vector" )
+                expect( type( Angle() ) ).to.equal( "Angle" )
+            end
+        },
+
+        {
+            name = "Does not error when called with no arguments",
+            func = function()
+                expect( function() return type() end ).notTo.err()
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/unpack.lua
+++ b/lua/tests/gmod/unit/globals/unpack.lua
@@ -1,0 +1,69 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:unpack",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( unpack ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns all elements of a sequential table",
+            func = function()
+                local first, second, third = unpack( { 1, 2, 3 } )
+
+                expect( first ).to.equal( 1 )
+                expect( second ).to.equal( 2 )
+                expect( third ).to.equal( 3 )
+            end
+        },
+
+        {
+            name = "Returns elements starting from the given index",
+            func = function()
+                local first, second = unpack( { "a", "b", "c" }, 2 )
+
+                expect( first ).to.equal( "b" )
+                expect( second ).to.equal( "c" )
+            end
+        },
+
+        {
+            name = "Respects an explicit start and end range",
+            func = function()
+                local first, second, third = unpack( { "a", "b", "c", "d" }, 2, 3 )
+
+                expect( first ).to.equal( "b" )
+                expect( second ).to.equal( "c" )
+                expect( third ).to.beNil()
+            end
+        },
+
+        {
+            name = "Returns nil values when the range extends past the table",
+            func = function()
+                local count = select( "#", unpack( {}, 1, 2 ) )
+                expect( count ).to.equal( 2 )
+            end
+        },
+
+        {
+            name = "Returns nothing for an empty table",
+            func = function()
+                local count = select( "#", unpack( {} ) )
+                expect( count ).to.equal( 0 )
+            end
+        },
+
+        {
+            name = "Errors when given a non-table",
+            func = function()
+                expect( function() unpack( "abc" ) end ).to.errWith( [[bad argument #1 to 'unpack' (table expected, got string)]] )
+                expect( function() unpack( 5 ) end ).to.errWith( [[bad argument #1 to 'unpack' (table expected, got number)]] )
+                expect( function() unpack( nil ) end ).to.errWith( [[bad argument #1 to 'unpack' (table expected, got nil)]] )
+            end
+        }
+    }
+}

--- a/lua/tests/gmod/unit/globals/xpcall.lua
+++ b/lua/tests/gmod/unit/globals/xpcall.lua
@@ -1,0 +1,91 @@
+--- @type GLuaTest_TestGroup
+return {
+    groupName = "Global:xpcall",
+    cases = {
+        {
+            name = "Exists on the Global table",
+            func = function()
+                expect( xpcall ).to.beA( "function" )
+            end
+        },
+
+        {
+            name = "Returns true and the return values when the function succeeds",
+            func = function()
+                local ok, value = xpcall( function() return "result" end, function() end )
+
+                expect( ok ).to.beTrue()
+                expect( value ).to.equal( "result" )
+            end
+        },
+
+        {
+            name = "Does not call the handler when the function succeeds",
+            func = function()
+                local handlerCalled = false
+                local ok = xpcall( function() return true end, function() handlerCalled = true end )
+
+                expect( ok ).to.beTrue()
+                expect( handlerCalled ).to.beFalse()
+            end
+        },
+
+        {
+            name = "Calls the handler with the error message when the function errors",
+            func = function()
+                local receivedError
+
+                local ok = xpcall( function()
+                    error( "xpcall test error", 0 )
+                end, function( err )
+                    receivedError = err
+                end )
+
+                expect( ok ).to.beFalse()
+                expect( receivedError ).to.equal( "xpcall test error" )
+            end
+        },
+
+        {
+            name = "Returns the handler's return value after an error",
+            func = function()
+                local ok, handled = xpcall( function()
+                    error( "boom", 0 )
+                end, function()
+                    return "handled"
+                end )
+
+                expect( ok ).to.beFalse()
+                expect( handled ).to.equal( "handled" )
+            end
+        },
+
+        {
+            name = "Passes extra arguments through to the called function",
+            func = function()
+                local ok, sum = xpcall( function( a, b ) return a + b end, function() end, 5, 6 )
+
+                expect( ok ).to.beTrue()
+                expect( sum ).to.equal( 11 )
+            end
+        },
+
+        {
+            name = "Returns false when given a non-function",
+            func = function()
+                local receivedError
+                local ok = xpcall( "not a function", function( err ) receivedError = err end )
+
+                expect( ok ).to.beFalse()
+                expect( receivedError ).to.equal( "attempt to call a string value" )
+            end
+        },
+
+        {
+            name = "Errors when the handler is not a function",
+            func = function()
+                expect( function() xpcall( function() end, "not a function" ) end ).to.errWith( [[bad argument #2 to 'xpcall' (function expected, got string)]] )
+            end
+        }
+    }
+}


### PR DESCRIPTION
I think that LLMs could, if used wisely and watched closely, could help us close the gap on the large amount of remaining tests.

I created an initial set of LLM guidance that I think it producing decent results on a few different models. I had it try some of the simplest remaining globals and was reasonably happy with the results.

I'll call this MVP for LLM assistance and will continue refining it.

(I was using some unreleased AI tools I've been working on - namely, a gmodwiki mcp and a local GLuaTest runner available to the LLM).

I'll make the GLuaTest LLM guidance available externally and then re-do the guidance in this repo to focus on gmod_tests specific matters.